### PR TITLE
Fix table close tag

### DIFF
--- a/xwiki.lua
+++ b/xwiki.lua
@@ -319,7 +319,7 @@ function Table(caption, aligns, widths, headers, rows)
     end
     add('</tr>')
   end
-  add('</table')
+  add('</table>')
   return table.concat(buffer,'\n')
 end
 


### PR DESCRIPTION
Tables are not rendered properly because of broken end tag.
This fixes the issue.
Tested locally.